### PR TITLE
keep the namespace XSolveAssert consistent and fix annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ options with their default values are shown on the example below:
 // src/AppBundle/Entity/User.php
 
 use Symfony\Component\Validator\Constraints as Assert;
-use XSolve\FaceValidatorBundle\Validator\Constraints\Face;
+use XSolve\FaceValidatorBundle\Validator\Constraints as XSolveAssert;
 
 class User
 {
@@ -163,7 +163,7 @@ class User
      * @var Symfony\Component\HttpFoundation\File\UploadedFile
 
      * @Assert\Image()
-     * @Assert\Face(
+     * @XSolveAssert\Face(
      *     minFaceRatio = 0.15,
      *     allowCoveringFace = true,
      *     maxFaceRotation = 20.0,


### PR DESCRIPTION
example with app available options will throw exception because class Assert\Face does not exist
This PR fixes this problem